### PR TITLE
Use analogread for triggering the fill sensors

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -29,6 +29,7 @@
 #define CO2_PURGE_RETRACTION_DELAY 1000
 #define CO2_PURGE_RETRACTION_PERIOD 500
 #define FILL_SENSORS_TIMER_FREQUENCY 100000 // 100ms This value needs to be defined in microseconds.
+#define FILL_SENSORS_TRIGGER 400 // Int between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
 
 /**
  * Feature flags

--- a/OpenBeerFiller.ino
+++ b/OpenBeerFiller.ino
@@ -85,15 +85,15 @@ void setupFillSensorsTimer() {
 void checkFillSensors() {
   Serial.println("Measured values:");
   Serial.println(analogRead(BEER_FILL_SENSOR_1));
-  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_1)) {
+  if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_1)) {
     triggerFullFillSensor1();
   }
   Serial.println(analogRead(BEER_FILL_SENSOR_2));
-  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_2)) {
+  if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_2)) {
     triggerFullFillSensor2();
   }
   Serial.println(analogRead(BEER_FILL_SENSOR_3));
-  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_3)) {
+  if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_3)) {
     triggerFullFillSensor3();
   }
 }

--- a/OpenBeerFiller.ino
+++ b/OpenBeerFiller.ino
@@ -83,8 +83,6 @@ void setupFillSensorsTimer() {
  * Check if the fill sensors have been triggered.
  */
 void checkFillSensors() {
-  Serial.println("Measured values:");
-  Serial.println(analogRead(BEER_FILL_SENSOR_1));
   if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_1)) {
     triggerFullFillSensor1();
   }

--- a/OpenBeerFiller.ino
+++ b/OpenBeerFiller.ino
@@ -86,11 +86,9 @@ void checkFillSensors() {
   if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_1)) {
     triggerFullFillSensor1();
   }
-  Serial.println(analogRead(BEER_FILL_SENSOR_2));
   if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_2)) {
     triggerFullFillSensor2();
   }
-  Serial.println(analogRead(BEER_FILL_SENSOR_3));
   if (FILL_SENSORS_TRIGGER < analogRead(BEER_FILL_SENSOR_3)) {
     triggerFullFillSensor3();
   }

--- a/OpenBeerFiller.ino
+++ b/OpenBeerFiller.ino
@@ -234,7 +234,7 @@ void startState() {
   moveBeerBelt();
   lowerFillerTubes();
   purgeCO2();
-  openAllBeerFillerTubes();  
+  openAllBeerFillerTubes();
   changeProgramState(FILLING);
 }
 

--- a/OpenBeerFiller.ino
+++ b/OpenBeerFiller.ino
@@ -63,9 +63,9 @@ void setupPins() {
   pinMode(BEER_BELT_SOL, OUTPUT);
 
   // Fill sensors.
-  pinMode(BEER_FILL_SENSOR_1, INPUT);
-  pinMode(BEER_FILL_SENSOR_2, INPUT);
-  pinMode(BEER_FILL_SENSOR_3, INPUT);
+  pinMode(BEER_FILL_SENSOR_1, OUTPUT);
+  pinMode(BEER_FILL_SENSOR_2, OUTPUT);
+  pinMode(BEER_FILL_SENSOR_3, OUTPUT);
 
   // Start/Stop button.
   pinMode(START_BUTTON, INPUT);
@@ -83,13 +83,17 @@ void setupFillSensorsTimer() {
  * Check if the fill sensors have been triggered.
  */
 void checkFillSensors() {
-  if(digitalRead(BEER_FILL_SENSOR_1)) {
+  Serial.println("Measured values:");
+  Serial.println(analogRead(BEER_FILL_SENSOR_1));
+  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_1)) {
     triggerFullFillSensor1();
   }
-  if(digitalRead(BEER_FILL_SENSOR_2)) {
+  Serial.println(analogRead(BEER_FILL_SENSOR_2));
+  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_2)) {
     triggerFullFillSensor2();
   }
-  if(digitalRead(BEER_FILL_SENSOR_3)) {
+  Serial.println(analogRead(BEER_FILL_SENSOR_3));
+  if (FILL_SENSORS_TRIGGER > analogRead(BEER_FILL_SENSOR_3)) {
     triggerFullFillSensor3();
   }
 }
@@ -232,7 +236,7 @@ void startState() {
   moveBeerBelt();
   lowerFillerTubes();
   purgeCO2();
-  openAllBeerFillerTubes();
+  openAllBeerFillerTubes();  
   changeProgramState(FILLING);
 }
 

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,7 @@ FILLER_TUBE_MOVEMENT_DELAY | How long in milliseconds to wait after raising/lowe
 MOVE_BEER_BELT_PERIOD | How long in milliseconds to run the beer belt solenoid for, ie how long should the beer belt move.
 FILL_SENSORS_TIMER_DELAY | How often in the background should the timer check the Fill sensors' status, defaults to every 100ms.
 CONINUOUS_FILLING | If this definition is enabled it will put the sketch in continous filling mode, meaning once it is done filling it will auto start with the next batch. This is for production use.
+FILL_SENSORS_TRIGGER | Sensitivity of the fill sensors, a value between 0 and 1023 representing the detected voltage.
 
 ### Required Libraries
 - [TimerOne](https://playground.arduino.cc/Code/Timer1/)


### PR DESCRIPTION
This PR converts the current digital input triggers to analog ones for detecting if a fill sensor was triggered, this is to overcome stopping to early due to head foam on the beer.

It works by detecting the voltage between the pin that is pulled down with a resistor and v+, the value can be set in the config.h file and must be an integer between 0 and 1023, how the number is obtained is by taking the voltage of the pin, 5v in Uno's case and then dividing it by 1024 and multiplying it with the voltage.

Closes #11 