### PR TITLE
Initial support for RRD Smart Controller

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -23,16 +23,15 @@
 /**
  * General Config Options
  */
-#define CO2_PURGE_PERIOD 2000
+#define CO2_PRE_PURGE_PERIOD 2000
 #define MOVE_BEER_BELT_PERIOD 5000
 #define FILLER_TUBE_MOVEMENT_DELAY 2000
-#define CO2_PURGE_RETRACTION_DELAY 1000
-#define CO2_PURGE_RETRACTION_PERIOD 500
+#define CO2_POST_PURGE_DELAY 1000
+#define CO2_POST_PURGE_PERIOD 500
 #define FILL_SENSORS_TIMER_FREQUENCY 100000 // 100ms This value needs to be defined in microseconds.
-const int FILL_SENSOR_TRIGGERS[] {400, 500, 600}; // Ints between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
+#define FILL_SENSOR_TRIGGER 400 // Ints between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
 
 /**
  * Feature flags
  */
-//#define CONINUOUS_FILLING // Uncomment this to have the filling process repeat for new batch after the current batch has completed it filling.
-//#define ENABLE_REPRAP_LCD
+//#define CONTINUOUS_FILLING // Uncomment this to have the filling process repeat for new batch after the current batch has completed it filling.

--- a/Config.h
+++ b/Config.h
@@ -29,7 +29,7 @@
 #define CO2_PURGE_RETRACTION_DELAY 1000
 #define CO2_PURGE_RETRACTION_PERIOD 500
 #define FILL_SENSORS_TIMER_FREQUENCY 100000 // 100ms This value needs to be defined in microseconds.
-#define FILL_SENSORS_TRIGGER 400 // Int between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
+#define DEFAULT_FILL_SENSORS_TRIGGER 400 // Int between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
 
 /**
  * Feature flags

--- a/Config.h
+++ b/Config.h
@@ -29,9 +29,10 @@
 #define CO2_PURGE_RETRACTION_DELAY 1000
 #define CO2_PURGE_RETRACTION_PERIOD 500
 #define FILL_SENSORS_TIMER_FREQUENCY 100000 // 100ms This value needs to be defined in microseconds.
-#define DEFAULT_FILL_SENSORS_TRIGGER 400 // Int between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
+const int FILL_SENSOR_TRIGGERS[] {400, 500, 600}; // Ints between 0 and 1023 used to trigger the fill sensor: operating voltage(5v or 3.3v) / 1024
 
 /**
  * Feature flags
  */
 //#define CONINUOUS_FILLING // Uncomment this to have the filling process repeat for new batch after the current batch has completed it filling.
+//#define ENABLE_REPRAP_LCD

--- a/InputConfig.h
+++ b/InputConfig.h
@@ -23,13 +23,13 @@
 /**
  * Pin definitions
  */
-#define START_BUTTON 8
-#define BEER_INLET_SOL_1 5
-#define BEER_INLET_SOL_2 6
-#define BEER_INLET_SOL_3 7
+#define START_BUTTON 10
+#define BEER_INLET_SOL_1 7
+#define BEER_INLET_SOL_2 8
+#define BEER_INLET_SOL_3 9
 #define BEER_FILL_SENSOR_1 A0
 #define BEER_FILL_SENSOR_2 A1
 #define BEER_FILL_SENSOR_3 A2
-#define CO2_PURGE_SOL 4
-#define FILL_RAIL_SOL 3
-#define BEER_BELT_SOL 2
+#define CO2_PURGE_SOL 6
+#define FILL_RAIL_SOL 5
+#define BEER_BELT_SOL 4

--- a/InputConfig.h
+++ b/InputConfig.h
@@ -33,3 +33,6 @@
 #define CO2_PURGE_SOL 6
 #define FILL_RAIL_SOL 5
 #define BEER_BELT_SOL 4
+#define ROT_ENC_A 2
+#define ROT_ENC_B 3
+#define ROT_ENC_BUTTON 12

--- a/ReprapLCD.cpp
+++ b/ReprapLCD.cpp
@@ -1,12 +1,19 @@
 #include "ReprapLCD.h"
 #include "Config.h"
+#include "InputConfig.h"
 
 LiquidCrystal_I2C lcd(0x27, 20, 4);
 char lines[4][21];
 
 /* Setup Rotary Encoder */
-Encoder rotEnc(2, 3);
-long oldPosition  = DEFAULT_FILL_SENSORS_TRIGGER;
+#define ENCODER_OPTIMIZE_INTERRUPTS
+Encoder rotEnc(ROT_ENC_A, ROT_ENC_B);
+int oldPosition, newPosition = 0;
+bool initializing = true;
+int currentTrigger, triggerPosition, triggerTotal, buttonState;
+int lastButtonState = HIGH;
+unsigned long lastDebounceTime = 0;
+unsigned long debounceDelay = 50;
 
 void updateLine(int line, char output[]) {
   sprintf(lines[line], "%-20s", output);
@@ -22,14 +29,58 @@ void updateLCD() {
 void setupLCD() {
   lcd.init();
   lcd.backlight();
+  updateLine(0, "Initialising...");
+  pinMode(ROT_ENC_BUTTON, INPUT);
+  triggerTotal = ((sizeof(FILL_SENSOR_TRIGGERS))/(sizeof(FILL_SENSOR_TRIGGERS[0])));
+  triggerPosition = 0;
+  oldPosition = FILL_SENSOR_TRIGGERS[triggerPosition];
+  currentTrigger = FILL_SENSOR_TRIGGERS[triggerPosition];
+}
+
+void readRotEncRotation() {
+  newPosition = rotEnc.read();
+  if (newPosition != oldPosition) {
+    oldPosition = newPosition / 4;
+    oldPosition += FILL_SENSOR_TRIGGERS[triggerPosition];
+    
+    if (oldPosition < 1)    { oldPosition = 0;    rotEnc.write(0); }
+    if (oldPosition > 1022) { oldPosition = 1023; newPosition = 1023; rotEnc.write(1023); }
+    currentTrigger = oldPosition;
+  }
+}
+
+void readRotEncButton() {
+  int reading = digitalRead(ROT_ENC_BUTTON);
+
+  if (reading != lastButtonState) {
+    lastDebounceTime = millis();
+  }
+
+  if ((millis() - lastDebounceTime) > debounceDelay) {
+    if (reading != buttonState) {
+      buttonState = reading;
+
+      // only toggle if the button state is LOW
+      if (buttonState == LOW) {
+        rotEnc.write(0);
+        
+        if (triggerPosition < triggerTotal-1) {
+          triggerPosition += 1;
+        }
+        else {
+          triggerPosition = 0;
+        }
+
+        currentTrigger = FILL_SENSOR_TRIGGERS[triggerPosition];
+      }
+    }
+  }
+
+  lastButtonState = reading;
 }
 
 int rotEncRead() {
-  long newPosition = rotEnc.read();
-  if (newPosition != oldPosition) {
-    oldPosition = newPosition + DEFAULT_FILL_SENSORS_TRIGGER;
-    if (oldPosition < 1) { oldPosition = 0; }
-    if (oldPosition > 1022) { oldPosition = 1023; newPosition = 1023; }
-    return oldPosition;
-  }
+  readRotEncButton();
+  readRotEncRotation();
+  return currentTrigger;
 }

--- a/ReprapLCD.cpp
+++ b/ReprapLCD.cpp
@@ -1,0 +1,35 @@
+#include "ReprapLCD.h"
+#include "Config.h"
+
+LiquidCrystal_I2C lcd(0x27, 20, 4);
+char lines[4][21];
+
+/* Setup Rotary Encoder */
+Encoder rotEnc(2, 3);
+long oldPosition  = DEFAULT_FILL_SENSORS_TRIGGER;
+
+void updateLine(int line, char output[]) {
+  sprintf(lines[line], "%-20s", output);
+}
+
+void updateLCD() {
+  for (int i = 0; i < 4; i++) {
+    lcd.setCursor(0,i);
+    lcd.print(lines[i]);
+  }
+}
+
+void setupLCD() {
+  lcd.init();
+  lcd.backlight();
+}
+
+int rotEncRead() {
+  long newPosition = rotEnc.read();
+  if (newPosition != oldPosition) {
+    oldPosition = newPosition + DEFAULT_FILL_SENSORS_TRIGGER;
+    if (oldPosition < 1) { oldPosition = 0; }
+    if (oldPosition > 1022) { oldPosition = 1023; newPosition = 1023; }
+    return oldPosition;
+  }
+}

--- a/ReprapLCD.cpp
+++ b/ReprapLCD.cpp
@@ -1,23 +1,54 @@
-#include "ReprapLCD.h"
-#include "Config.h"
-#include "InputConfig.h"
 
+#pragma once
+#include "ReprapLCD.h"
+
+/* Setup 2040 LCD */
 LiquidCrystal_I2C lcd(0x27, 20, 4);
 char lines[4][21];
 
 /* Setup Rotary Encoder */
 #define ENCODER_OPTIMIZE_INTERRUPTS
 Encoder rotEnc(ROT_ENC_A, ROT_ENC_B);
-int oldPosition, newPosition = 0;
+int oldPosition, newPosition;
 bool initializing = true;
-int currentTrigger, triggerPosition, triggerTotal, buttonState;
+int buttonState;
 int lastButtonState = HIGH;
 unsigned long lastDebounceTime = 0;
 unsigned long debounceDelay = 50;
 
+/* Setup Menu Stuff */
+int menuScreenPosition, cursorPos = 0;
+enum displayPage {HOME,MENU,VALUE};
+displayPage currentPage = HOME;
+enum menuSelect {
+                  HOME_SCREEN, 
+                  MOVE_BEER_BELT_TIME,
+                  FILL_TRIG, 
+                  PRE_PURGE_TIME, 
+                  POST_PURGE_TIME,
+                  POST_PURGE_DELAY,
+                  FILLER_TUBE_DELAY
+                  
+};
+menuSelect currentSelection = HOME_SCREEN;
+char menuListText[][21] = {
+                  "Home Screen", 
+                  "Belt Movement Time", 
+                  "Fill Trigger", 
+                  "Pre Purge Time", 
+                  "Post Purge Time",
+                  "Post Purge Delay", 
+                  "Filler Tube Delay"
+};
+int menuListLength = ((sizeof(menuListText))/(sizeof(menuListText[0])));
+int valueBuffer;
+bool fromMenu;
+
+
 void updateLine(int line, char output[]) {
   sprintf(lines[line], "%-20s", output);
 }
+
 
 void updateLCD() {
   for (int i = 0; i < 4; i++) {
@@ -26,32 +57,144 @@ void updateLCD() {
   }
 }
 
+
 void setupLCD() {
   lcd.init();
   lcd.backlight();
   updateLine(0, "Initialising...");
   pinMode(ROT_ENC_BUTTON, INPUT);
-  triggerTotal = ((sizeof(FILL_SENSOR_TRIGGERS))/(sizeof(FILL_SENSOR_TRIGGERS[0])));
-  triggerPosition = 0;
-  oldPosition = FILL_SENSOR_TRIGGERS[triggerPosition];
-  currentTrigger = FILL_SENSOR_TRIGGERS[triggerPosition];
+  initializing = false;
+  updateLCD();
 }
 
+
+void showDisplay(char currentStateText[], int filledCans) {
+  char lineText[4][21] = {" ", " ", " ", " "};
+
+  switch(currentPage) {
+    case HOME: 
+      sprintf(lineText[0], "%s%s", "Status: ", currentStateText);
+      sprintf(lineText[1], "%s%i", "Cans Filled: ", filledCans);
+      break;
+
+    case MENU:
+      cursorPos = currentSelection - menuScreenPosition;
+      lineText[cursorPos][0] = 62; // >
+
+      sprintf(lineText[0], "%s%s", lineText[0], menuListText[menuScreenPosition]);
+      sprintf(lineText[1], "%s%s", lineText[1], menuListText[menuScreenPosition+1]);
+      sprintf(lineText[2], "%s%s", lineText[2], menuListText[menuScreenPosition+2]);
+      sprintf(lineText[3], "%s%s", lineText[3], menuListText[menuScreenPosition+3]);
+      break;
+
+    case VALUE:
+      switch (currentSelection) {
+        case MOVE_BEER_BELT_TIME:
+          sprintf(lineText[0], "%s", "Belt Movement");
+          sprintf(lineText[2], "%s%i", "Time in ms: ", valueBuffer);
+          break;
+        case FILL_TRIG:
+          sprintf(lineText[0], "%s", "Fill Trigger");
+          sprintf(lineText[2], "%s%i", "Trigger value: ", valueBuffer);
+          break;
+        case PRE_PURGE_TIME:
+          sprintf(lineText[0], "%s", "Pre Purge Time");
+          sprintf(lineText[2], "%s%i", "Time in ms: ", valueBuffer);
+          break;
+        case POST_PURGE_TIME:
+          sprintf(lineText[0], "%s", "Post Purge Time");
+          sprintf(lineText[2], "%s%i", "Time in ms: ", valueBuffer);
+          break;
+        case POST_PURGE_DELAY:
+          sprintf(lineText[0], "%s", "Post Purge Delay");
+          sprintf(lineText[2], "%s%i", "Time in ms: ", valueBuffer);
+          break;
+        case FILLER_TUBE_DELAY:
+          sprintf(lineText[0], "%s", "Filler Tube Delay");
+          sprintf(lineText[2], "%s%i", "Time in ms: ", valueBuffer);
+          break;
+      }
+      break;
+  }
+
+  updateLine(0, lineText[0]);
+  updateLine(1, lineText[1]);
+  updateLine(2, lineText[2]);
+  updateLine(3, lineText[3]);
+  updateLCD();
+}
+
+
+int valueLowHigh(int rotEncncPosition, int lowVal, int highVal) {
+  if (rotEncncPosition < (lowVal+1))    { rotEncncPosition = lowVal;  rotEnc.write(lowVal); }
+  if (rotEncncPosition > (highVal-1))   { rotEncncPosition = highVal; rotEnc.write(highVal); }
+  return rotEncncPosition;
+}
+
+
 void readRotEncRotation() {
-  newPosition = rotEnc.read();
-  if (newPosition != oldPosition) {
-    oldPosition = newPosition / 4;
-    oldPosition += FILL_SENSOR_TRIGGERS[triggerPosition];
-    
-    if (oldPosition < 1)    { oldPosition = 0;    rotEnc.write(0); }
-    if (oldPosition > 1022) { oldPosition = 1023; newPosition = 1023; rotEnc.write(1023); }
-    currentTrigger = oldPosition;
+  newPosition = rotEnc.read() / 4;
+  switch(currentPage) {
+    case HOME:
+      break;
+
+    case MENU:
+      if (newPosition < 1) { newPosition = 0; rotEnc.write(0);}
+      if (newPosition > (menuListLength-2)) { newPosition = menuListLength-1; rotEnc.write(newPosition * 4);}
+
+      // Check if we need to scroll the screen
+      // Cursor Moved Down
+      if (newPosition > currentSelection) {
+        if ((newPosition-3) > menuScreenPosition) {
+          menuScreenPosition++;
+        }
+      }
+      
+      // Cursor Moved Up
+      if (newPosition < menuScreenPosition) {
+        menuScreenPosition--;
+      }
+
+      // Stop the cursor going too far
+      if (newPosition > (menuScreenPosition + 3)) {newPosition = menuScreenPosition + 3;}
+      currentSelection = newPosition;
+      break;
+
+     case VALUE:
+      int x;
+      if (fromMenu) {
+        newPosition = valueBuffer;
+        fromMenu = false;
+      }
+      
+       switch(currentSelection) {
+        case MOVE_BEER_BELT_TIME:
+          x = valueLowHigh(newPosition, 0, 32767);
+          break;
+        case FILL_TRIG:
+          x = valueLowHigh(newPosition, 0, 1023);
+          break;
+        case PRE_PURGE_TIME:
+          x = valueLowHigh(newPosition, 0, 32767);
+          break;
+        case POST_PURGE_TIME:
+          x = valueLowHigh(newPosition, 0, 32767);
+          break;
+        case POST_PURGE_DELAY:
+          x = valueLowHigh(newPosition, 0, 32767);
+          break;
+        case FILLER_TUBE_DELAY:
+          x = valueLowHigh(newPosition, 0, 32767);
+          break;
+      }
+      valueBuffer = x;
+      break;
   }
 }
 
+
 void readRotEncButton() {
   int reading = digitalRead(ROT_ENC_BUTTON);
-
   if (reading != lastButtonState) {
     lastDebounceTime = millis();
   }
@@ -62,16 +205,54 @@ void readRotEncButton() {
 
       // only toggle if the button state is LOW
       if (buttonState == LOW) {
-        rotEnc.write(0);
-        
-        if (triggerPosition < triggerTotal-1) {
-          triggerPosition += 1;
-        }
-        else {
-          triggerPosition = 0;
-        }
 
-        currentTrigger = FILL_SENSOR_TRIGGERS[triggerPosition];
+        switch(currentPage) {
+          case HOME:
+            currentPage = MENU;
+            currentSelection = HOME_SCREEN;
+            rotEnc.write(0);
+            break;
+
+          case MENU:
+            fromMenu = true;
+            valueBuffer = EEPROM16_Read(currentSelection*10);
+            rotEnc.write(valueBuffer*4);
+
+            switch(currentSelection) {
+              case HOME_SCREEN:
+                currentPage = HOME;
+                break;
+              case MOVE_BEER_BELT_TIME:
+                currentPage = VALUE;
+                break;
+              case FILL_TRIG:
+                currentPage = VALUE;
+                break;
+              case PRE_PURGE_TIME:
+                currentPage = VALUE;
+                break;
+              case POST_PURGE_TIME:
+                currentPage = VALUE;
+                break;
+              case POST_PURGE_DELAY:
+                currentPage = VALUE;
+                break;
+              case FILLER_TUBE_DELAY:
+                currentPage = VALUE;
+                break;
+            }
+            break;
+
+          case VALUE:
+            if (EEPROM16_Read(currentSelection*10) != valueBuffer) {
+              // Only write to EEPROM if we have to
+              EEPROM16_Write(currentSelection*10, valueBuffer);
+            }
+            newPosition = currentSelection;
+            rotEnc.write(currentSelection*4);
+            currentPage = MENU;
+            break;
+        }
       }
     }
   }
@@ -79,8 +260,8 @@ void readRotEncButton() {
   lastButtonState = reading;
 }
 
-int rotEncRead() {
+
+void rotEncRead() {
   readRotEncButton();
   readRotEncRotation();
-  return currentTrigger;
 }

--- a/ReprapLCD.h
+++ b/ReprapLCD.h
@@ -1,0 +1,8 @@
+#include <Wire.h>
+#include <LiquidCrystal_I2C.h> // LiquidCrystal_I2C.h: https://github.com/johnrickman/LiquidCrystal_I2C
+#include <Encoder.h> // http://www.pjrc.com/teensy/td_libs_Encoder.html
+
+void updateLine(int line, char output[]);
+void updateLCD();
+void setupLCD();
+int rotEncRead();

--- a/ReprapLCD.h
+++ b/ReprapLCD.h
@@ -1,8 +1,13 @@
+
+#pragma once
 #include <Wire.h>
 #include <LiquidCrystal_I2C.h> // LiquidCrystal_I2C.h: https://github.com/johnrickman/LiquidCrystal_I2C
 #include <Encoder.h> // http://www.pjrc.com/teensy/td_libs_Encoder.html
 
+#include "InputConfig.h"
+#include "Settings.h"
+
 void updateLine(int line, char output[]);
-void updateLCD();
 void setupLCD();
-int rotEncRead();
+void rotEncRead();
+void showDisplay(char currentStateText[], int filledCans);

--- a/Settings.cpp
+++ b/Settings.cpp
@@ -1,0 +1,34 @@
+
+#pragma once
+#include "Settings.h"
+int settingsVersion = 1;
+
+
+
+void EEPROM16_Write(uint8_t a, uint16_t b) {
+  Serial.println("Writing to EEPROM");
+  EEPROM.write(a, lowByte(b));
+  EEPROM.write(a+1, highByte(b));
+}
+
+
+uint16_t EEPROM16_Read(uint8_t a) {
+  return word(EEPROM.read(a+1), EEPROM.read(a));
+}
+
+
+void firstRunSettings() {
+  // If EEPROM position 0 has not been set to settingsVersion, assume first run
+  if (!(EEPROM16_Read(0) == settingsVersion)) { 
+
+    // Write defaults to EEPROM
+    EEPROM16_Write(EEPROM_MOVE_BEER_BELT_PERIOD, MOVE_BEER_BELT_PERIOD);
+    EEPROM16_Write(EEPROM_FILL_SENSOR_TRIGGER, FILL_SENSOR_TRIGGER);
+    EEPROM16_Write(EEPROM_CO2_PRE_PURGE_PERIOD, CO2_PRE_PURGE_PERIOD);
+    EEPROM16_Write(EEPROM_CO2_POST_PURGE_PERIOD, CO2_POST_PURGE_PERIOD);
+    EEPROM16_Write(EEPROM_CO2_POST_PURGE_DELAY, CO2_POST_PURGE_DELAY);
+    EEPROM16_Write(EEPROM_FILLER_TUBE_MOVEMENT_DELAY, FILLER_TUBE_MOVEMENT_DELAY);
+
+    EEPROM16_Write(0, settingsVersion);
+  }
+}

--- a/Settings.h
+++ b/Settings.h
@@ -1,0 +1,17 @@
+
+#pragma once
+#include <EEPROM.h>
+#include <Arduino.h>
+#include "Config.h"
+#include "InputConfig.h"
+
+#define EEPROM_MOVE_BEER_BELT_PERIOD 10
+#define EEPROM_FILL_SENSOR_TRIGGER 20
+#define EEPROM_CO2_PRE_PURGE_PERIOD 30
+#define EEPROM_CO2_POST_PURGE_PERIOD 40
+#define EEPROM_CO2_POST_PURGE_DELAY 50
+#define EEPROM_FILLER_TUBE_MOVEMENT_DELAY 60
+
+void firstRunSettings();
+void EEPROM16_Write(uint8_t a, uint16_t b);
+uint16_t EEPROM16_Read(uint8_t a);


### PR DESCRIPTION
This commit adds basic support for the RRD Smart controller utilizing the LCD to display current status and the rotary encoder to control the trigger value for the filler tubes. It is also an alternative to using a pot to adjust the trigger value

The RRD Smart Controller is a cheap LCD module that includes a 2004 LCD, rotary encoder, momentary button, piezo buzzer & SD card holder. See: https://reprap.org/wiki/RepRapDiscount_Smart_Controller

These modules are cheap and readily available via the usual sources (ebay, aliexpress, amazon, etc) .
Example: https://www.aliexpress.com/item/32616537620.html
Due to the limited pins on the Uno, I also used an I2C interface adapter for the LCD.
Example: https://www.aliexpress.com/item/32984942286.html

I don't expect this PR to be pulled as is, but as it stands I have moved the default output pins to allow the rotary encoder to utilise the interupt pins of the UNO. There are 2 added dependencies in the LiquidCrystal_I2C library and the Encoder library.

Quick example of the result: https://www.youtube.com/watch?v=qLlBS2Bm4B4